### PR TITLE
Added entrypoint script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,6 @@ RUN vca-install-package \
   bzip2 \
   gzip \
   xz-utils
+
+ADD entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/bin/sh", "/opt/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Testing System installed ready for testing shell scripts
   * [`gzip`](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=gzip)
   * [`xz-utils`](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=xz-utils)
   * [`openssh-client`](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=openssh-client)
+  * [`openssh-server`](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=openssh-server)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,10 @@ start_sshd() {
   readonly known_hosts="${ssh}/known_hosts"
   readonly authorized="${ssh}/authorized_keys"
 
+  # Ensure files and directories exist.
+  mkdir -p "$ssh"
+  touch "$known_hosts"
+  touch "$authorized"
   # Note the trailing space (after "localhost ") is required for the known_hosts format.
   printf "localhost " >> "$known_hosts"
   cat "$public" >> "$known_hosts"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Adds the rsa public key to known_hosts and authorized_keys (so the host can
+# connect to itself via ssh without a tty) and then starts the ssh deamon for
+# the Docker image.
+
+set -eu
+IFS='
+	'
+
+
+start_sshd() {
+  readonly ssh="${HOME}/.ssh"
+  readonly public="${ssh}/id_rsa.pub"
+  readonly known_hosts="${ssh}/known_hosts"
+  readonly authorized="${ssh}/authorized_keys"
+
+  # Note the trailing space (after "localhost ") is required for the known_hosts format.
+  printf "localhost " >> "$known_hosts"
+  cat "$public" >> "$known_hosts"
+  cat "$public" >> "$authorized"
+
+  /usr/sbin/sshd -h "$HOME/.ssh/id_rsa"
+}
+
+start_sshd "$@"


### PR DESCRIPTION
This PR adds the entrypoint.sh script to the docker image.

Currently, it adds the rsa public key to known_hosts and authorized_keys (so the host can connect to itself via ssh without a tty) and then starts the ssh deamon for the Docker image.